### PR TITLE
Fuzz GPS

### DIFF
--- a/Beiwe.xcodeproj/project.pbxproj
+++ b/Beiwe.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1173B23E1EF4B39C998B16DD /* Pods_Beiwe.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3F49D21194624D3A52EF64D /* Pods_Beiwe.framework */; };
 		831CC5801F79AF6400CDEFB0 /* AppEventManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 831CC57F1F79AF6400CDEFB0 /* AppEventManager.swift */; };
 		832FFC1E1CC8506900F2E1EF /* GradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 832FFC1D1CC8506900F2E1EF /* GradientView.swift */; };
 		832FFC221CC85A7C00F2E1EF /* BWButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 832FFC211CC85A7C00F2E1EF /* BWButton.swift */; };
@@ -75,15 +76,13 @@
 		83F98C441C923C3600E0B64B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 83F98C421C923C3600E0B64B /* LaunchScreen.storyboard */; };
 		83FDCFD81CBC8E4700AFF716 /* TrackingSurveyPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83FDCFD71CBC8E4700AFF716 /* TrackingSurveyPresenter.swift */; };
 		83FDCFDA1CBCB6D300AFF716 /* ChangePasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83FDCFD91CBCB6D300AFF716 /* ChangePasswordViewController.swift */; };
-		D7393008AC8F91CFA8F75459 /* Pods_Beiwe.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D01E03E1685830D938B345DA /* Pods_Beiwe.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		0C28CF531AD7B3D35000BA28 /* Pods-Beiwe.testflight kg.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Beiwe.testflight kg.xcconfig"; path = "Pods/Target Support Files/Pods-Beiwe/Pods-Beiwe.testflight kg.xcconfig"; sourceTree = "<group>"; };
-		1859E756C67EFE5FEECB7BEE /* Pods-Beiwe.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Beiwe.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Beiwe/Pods-Beiwe.debug.xcconfig"; sourceTree = "<group>"; };
-		36EDF07B2D8E6AF15C179925 /* Pods-Beiwe.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Beiwe.release.xcconfig"; path = "Pods/Target Support Files/Pods-Beiwe/Pods-Beiwe.release.xcconfig"; sourceTree = "<group>"; };
-		38F9762E5747F220806BB64A /* Pods-Beiwe.testflight external.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Beiwe.testflight external.xcconfig"; path = "Pods/Target Support Files/Pods-Beiwe/Pods-Beiwe.testflight external.xcconfig"; sourceTree = "<group>"; };
+		17C4B8175F8CF5B5407DEA50 /* Pods-Beiwe.testflight kg.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Beiwe.testflight kg.xcconfig"; path = "Pods/Target Support Files/Pods-Beiwe/Pods-Beiwe.testflight kg.xcconfig"; sourceTree = "<group>"; };
 		4D73594BB9D98FBE3AA1E023 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6BE1CD8AB3101933EE9A89CE /* Pods-Beiwe.testflight internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Beiwe.testflight internal.xcconfig"; path = "Pods/Target Support Files/Pods-Beiwe/Pods-Beiwe.testflight internal.xcconfig"; sourceTree = "<group>"; };
+		7804DE752C816F583949D1A4 /* Pods-Beiwe.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Beiwe.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Beiwe/Pods-Beiwe.debug.xcconfig"; sourceTree = "<group>"; };
 		831CC57F1F79AF6400CDEFB0 /* AppEventManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEventManager.swift; sourceTree = "<group>"; };
 		832FFC1D1CC8506900F2E1EF /* GradientView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GradientView.swift; sourceTree = "<group>"; };
 		832FFC211CC85A7C00F2E1EF /* BWButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BWButton.swift; sourceTree = "<group>"; };
@@ -163,9 +162,10 @@
 		83F98C451C923C3600E0B64B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		83FDCFD71CBC8E4700AFF716 /* TrackingSurveyPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackingSurveyPresenter.swift; sourceTree = "<group>"; };
 		83FDCFD91CBCB6D300AFF716 /* ChangePasswordViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChangePasswordViewController.swift; sourceTree = "<group>"; };
-		D01E03E1685830D938B345DA /* Pods_Beiwe.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Beiwe.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		D4903A730C06BC2993F77F77 /* Pods-Beiwe.testflight internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Beiwe.testflight internal.xcconfig"; path = "Pods/Target Support Files/Pods-Beiwe/Pods-Beiwe.testflight internal.xcconfig"; sourceTree = "<group>"; };
-		FB6A8DD0D5BBD86CEBD12A4A /* Pods-Beiwe.harvard.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Beiwe.harvard.xcconfig"; path = "Pods/Target Support Files/Pods-Beiwe/Pods-Beiwe.harvard.xcconfig"; sourceTree = "<group>"; };
+		94A69B255EC17D5859DD273C /* Pods-Beiwe.harvard.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Beiwe.harvard.xcconfig"; path = "Pods/Target Support Files/Pods-Beiwe/Pods-Beiwe.harvard.xcconfig"; sourceTree = "<group>"; };
+		A3F49D21194624D3A52EF64D /* Pods_Beiwe.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Beiwe.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D16F300F4AD663617AEF4916 /* Pods-Beiwe.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Beiwe.release.xcconfig"; path = "Pods/Target Support Files/Pods-Beiwe/Pods-Beiwe.release.xcconfig"; sourceTree = "<group>"; };
+		F69132CC13AD41995B997EEB /* Pods-Beiwe.testflight external.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Beiwe.testflight external.xcconfig"; path = "Pods/Target Support Files/Pods-Beiwe/Pods-Beiwe.testflight external.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -173,22 +173,22 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D7393008AC8F91CFA8F75459 /* Pods_Beiwe.framework in Frameworks */,
+				1173B23E1EF4B39C998B16DD /* Pods_Beiwe.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		0E527189090F10B66CB4ACB6 /* Pods */ = {
+		4424C1B68D81046E90E74510 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				1859E756C67EFE5FEECB7BEE /* Pods-Beiwe.debug.xcconfig */,
-				D4903A730C06BC2993F77F77 /* Pods-Beiwe.testflight internal.xcconfig */,
-				0C28CF531AD7B3D35000BA28 /* Pods-Beiwe.testflight kg.xcconfig */,
-				38F9762E5747F220806BB64A /* Pods-Beiwe.testflight external.xcconfig */,
-				36EDF07B2D8E6AF15C179925 /* Pods-Beiwe.release.xcconfig */,
-				FB6A8DD0D5BBD86CEBD12A4A /* Pods-Beiwe.harvard.xcconfig */,
+				7804DE752C816F583949D1A4 /* Pods-Beiwe.debug.xcconfig */,
+				6BE1CD8AB3101933EE9A89CE /* Pods-Beiwe.testflight internal.xcconfig */,
+				17C4B8175F8CF5B5407DEA50 /* Pods-Beiwe.testflight kg.xcconfig */,
+				F69132CC13AD41995B997EEB /* Pods-Beiwe.testflight external.xcconfig */,
+				D16F300F4AD663617AEF4916 /* Pods-Beiwe.release.xcconfig */,
+				94A69B255EC17D5859DD273C /* Pods-Beiwe.harvard.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -197,7 +197,7 @@
 			isa = PBXGroup;
 			children = (
 				4D73594BB9D98FBE3AA1E023 /* Pods.framework */,
-				D01E03E1685830D938B345DA /* Pods_Beiwe.framework */,
+				A3F49D21194624D3A52EF64D /* Pods_Beiwe.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -356,7 +356,7 @@
 				83F98C381C923C3600E0B64B /* Beiwe */,
 				83F98C371C923C3600E0B64B /* Products */,
 				5EEADFF9AED027E0BE53BF6C /* Frameworks */,
-				0E527189090F10B66CB4ACB6 /* Pods */,
+				4424C1B68D81046E90E74510 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -400,7 +400,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 83F98C481C923C3600E0B64B /* Build configuration list for PBXNativeTarget "Beiwe" */;
 			buildPhases = (
-				75362CF9B47E2F2739460379 /* [CP] Check Pods Manifest.lock */,
+				3117C101E3641DF554EA5CF8 /* [CP] Check Pods Manifest.lock */,
 				83F98C321C923C3600E0B64B /* Sources */,
 				83F98C331C923C3600E0B64B /* Frameworks */,
 				83F98C341C923C3600E0B64B /* Resources */,
@@ -408,8 +408,7 @@
 				83F98C501C925F2500E0B64B /* ShellScript */,
 				83F98C511C925F6F00E0B64B /* ShellScript */,
 				83F98C4F1C9250A600E0B64B /* Run Script */,
-				01F202B01C005ABDD8F3C785 /* [CP] Embed Pods Frameworks */,
-				758CE49DFF02DD1C661AE1B2 /* [CP] Copy Pods Resources */,
+				A0946EA2265200164FEAE555 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -432,8 +431,9 @@
 				TargetAttributes = {
 					83F98C351C923C3600E0B64B = {
 						CreatedOnToolsVersion = 7.2;
-						DevelopmentTeam = 6M52R5C7FT;
+						DevelopmentTeam = WRY9L72ZUW;
 						LastSwiftMigration = 0830;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -473,85 +473,26 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		01F202B01C005ABDD8F3C785 /* [CP] Embed Pods Frameworks */ = {
+		3117C101E3641DF554EA5CF8 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Beiwe/Pods-Beiwe-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
-				"${BUILT_PRODUCTS_DIR}/EmitterKit/EmitterKit.framework",
-				"${BUILT_PRODUCTS_DIR}/Eureka/Eureka.framework",
-				"${BUILT_PRODUCTS_DIR}/Hakuba/Hakuba.framework",
-				"${BUILT_PRODUCTS_DIR}/IDZSwiftCommonCrypto/IDZSwiftCommonCrypto.framework",
-				"${BUILT_PRODUCTS_DIR}/KeychainSwift/KeychainSwift.framework",
-				"${BUILT_PRODUCTS_DIR}/ObjcExceptionBridging/ObjcExceptionBridging.framework",
-				"${BUILT_PRODUCTS_DIR}/ObjectMapper/ObjectMapper.framework",
-				"${BUILT_PRODUCTS_DIR}/PKHUD/PKHUD.framework",
-				"${BUILT_PRODUCTS_DIR}/PermissionScope/PermissionScope.framework",
-				"${BUILT_PRODUCTS_DIR}/PromiseKit/PromiseKit.framework",
-				"${BUILT_PRODUCTS_DIR}/ReachabilitySwift/ReachabilitySwift.framework",
-				"${BUILT_PRODUCTS_DIR}/ResearchKit/ResearchKit.framework",
-				"${BUILT_PRODUCTS_DIR}/SwiftValidator/SwiftValidator.framework",
-				"${BUILT_PRODUCTS_DIR}/XCGLogger/XCGLogger.framework",
-				"${BUILT_PRODUCTS_DIR}/XLActionController/XLActionController.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/EmitterKit.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Eureka.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Hakuba.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/IDZSwiftCommonCrypto.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/KeychainSwift.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ObjcExceptionBridging.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ObjectMapper.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PKHUD.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PermissionScope.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PromiseKit.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ReachabilitySwift.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ResearchKit.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftValidator.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/XCGLogger.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/XLActionController.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Beiwe/Pods-Beiwe-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		75362CF9B47E2F2739460379 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
+			inputFileListPaths = (
 			);
 			inputPaths = (
 				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
 				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/Pods-Beiwe-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		758CE49DFF02DD1C661AE1B2 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Beiwe/Pods-Beiwe-resources.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		83E3DE861CA3A41E00EB5349 /* ShellScript */ = {
@@ -565,7 +506,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "echo \"Bundle ID: \" ${PRODUCT_BUNDLE_IDENTIFIER}\necho \"Product name: \" ${PRODUCT_NAME}\necho \"Copy Configuration files: ${TARGET_NAME_SUFFIX}\"\nCONFIG_NAME=${TARGET_NAME_SUFFIX}\nif [ \"$CONFIG_NAME\" == \"\" ]; then\n    CONFIG_NAME=\"Prod\"\nfi\necho $CONFIG_NAME\ncp \"${SRCROOT}/Beiwe/Configuration/Config-Default.plist\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app\"\ncp \"${SRCROOT}/Beiwe/Configuration/Config-${CONFIG_NAME}.plist\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/Config.plist\"";
+			shellScript = "echo \"Bundle ID: \" ${PRODUCT_BUNDLE_IDENTIFIER}\necho \"Product name: \" ${PRODUCT_NAME}\necho \"Copy Configuration files: ${TARGET_NAME_SUFFIX}\"\nCONFIG_NAME=${TARGET_NAME_SUFFIX}\nif [ \"$CONFIG_NAME\" == \"\" ]; then\n    CONFIG_NAME=\"Prod\"\nfi\necho $CONFIG_NAME\ncp \"${SRCROOT}/Beiwe/Configuration/Config-Default.plist\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app\"\ncp \"${SRCROOT}/Beiwe/Configuration/Config-${CONFIG_NAME}.plist\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/Config.plist\"\n";
 		};
 		83F98C4F1C9250A600E0B64B /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -606,6 +547,58 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "# Skip icon badging for now...\nexit 0\nif [[ \"$CONFIGURATION\" == \"Release\" ]]; then\n  exit 0\nfi\nIFS=$'\\n'\n#VERSION=`git describe --dirty |sed -e \"s/^[^0-9]*//\"`\nBUILD=$(/usr/libexec/PlistBuddy -c \"Print CFBundleVersion\" \"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\")\nVERSION=$(/usr/libexec/PlistBuddy -c \"Print CFBundleShortVersionString\" \"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\")\n#VERSION=\"0.1.2-243-abcdefg\"\nPATH=${PATH}:/usr/local/bin\necho \"Ver: $VERSION, build: $BUILD\"\n\nfunction generateIcon () {\n    BASE_IMAGE_NAME=$1\n\n    TARGET_PATH=\"${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/${BASE_IMAGE_NAME}\"\n    echo $TARGET_PATH\n    echo $SRCROOT\n    echo $(find ${SRCROOT} -name \"AppIcon60x60@2x.png\")\n    BASE_IMAGE_PATH=$(find ${SRCROOT} -name ${BASE_IMAGE_NAME})\n    WIDTH=$(identify -format %w ${BASE_IMAGE_PATH})\n    NAME_FONT_SIZE=$(echo \"$WIDTH * .20\" | bc -l)\n    VERSION_FONT_SIZE=$(echo \"$WIDTH * .12\" | bc -l)\n    echo \"font size $NAME_FONT_SIZE, $VERSION_FONT_SIZE\"\n\n\n    convert ${BASE_IMAGE_PATH} -fill white -font Times-Bold -pointsize ${NAME_FONT_SIZE} -gravity north -annotate +0+3 ${TARGET_NAME_SUFFIX} -gravity south -pointsize ${VERSION_FONT_SIZE} -annotate +0+5 \"${BUILD}\" ${TARGET_PATH}\n}\n\ngenerateIcon \"AppIcon60x60@2x.png\"\n#generateIcon \"AppIcon60x60@3x.png\"\n#generateIcon \"AppIcon76x76~ipad.png\"\n#generateIcon \"AppIcon76x76@2x~ipad.png\"";
+		};
+		A0946EA2265200164FEAE555 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-Beiwe/Pods-Beiwe-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
+				"${BUILT_PRODUCTS_DIR}/EmitterKit/EmitterKit.framework",
+				"${BUILT_PRODUCTS_DIR}/Eureka/Eureka.framework",
+				"${BUILT_PRODUCTS_DIR}/Hakuba/Hakuba.framework",
+				"${BUILT_PRODUCTS_DIR}/IDZSwiftCommonCrypto/IDZSwiftCommonCrypto.framework",
+				"${BUILT_PRODUCTS_DIR}/KeychainSwift/KeychainSwift.framework",
+				"${BUILT_PRODUCTS_DIR}/ObjcExceptionBridging/ObjcExceptionBridging.framework",
+				"${BUILT_PRODUCTS_DIR}/ObjectMapper/ObjectMapper.framework",
+				"${BUILT_PRODUCTS_DIR}/PKHUD/PKHUD.framework",
+				"${BUILT_PRODUCTS_DIR}/PermissionScope/PermissionScope.framework",
+				"${BUILT_PRODUCTS_DIR}/PromiseKit/PromiseKit.framework",
+				"${BUILT_PRODUCTS_DIR}/ReachabilitySwift/ReachabilitySwift.framework",
+				"${BUILT_PRODUCTS_DIR}/ResearchKit/ResearchKit.framework",
+				"${BUILT_PRODUCTS_DIR}/SwiftValidator/SwiftValidator.framework",
+				"${BUILT_PRODUCTS_DIR}/XCGLogger/XCGLogger.framework",
+				"${BUILT_PRODUCTS_DIR}/XLActionController/XLActionController.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/EmitterKit.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Eureka.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Hakuba.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/IDZSwiftCommonCrypto.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/KeychainSwift.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ObjcExceptionBridging.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ObjectMapper.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PKHUD.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PermissionScope.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PromiseKit.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ReachabilitySwift.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ResearchKit.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftValidator.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/XCGLogger.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/XLActionController.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Beiwe/Pods-Beiwe-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -757,17 +750,22 @@
 		};
 		83AF04231CAD6CE700A37225 /* TestFlight KG */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0C28CF531AD7B3D35000BA28 /* Pods-Beiwe.testflight kg.xcconfig */;
+			baseConfigurationReference = 17C4B8175F8CF5B5407DEA50 /* Pods-Beiwe.testflight kg.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BUNDLE_ID_SUFFIX = kgint;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = WRY9L72ZUW;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Beiwe/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				ONLY_ACTIVE_ARCH = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = com.rocketfarmstudios.kg.beiwe.kgint;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zagaran.beiwe.jj;
 				PRODUCT_NAME = "$(TARGET_NAME)${TARGET_NAME_SUFFIX}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Beiwe-Bridging-Header.h";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -855,8 +853,8 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "iPhone Distribution: Jukka-Pekka Onnela (6M52R5C7FT)";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution: Jukka-Pekka Onnela (6M52R5C7FT)";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_BITCODE = NO;
@@ -882,20 +880,23 @@
 		};
 		83F98C491C923C3600E0B64B /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1859E756C67EFE5FEECB7BEE /* Pods-Beiwe.debug.xcconfig */;
+			baseConfigurationReference = 7804DE752C816F583949D1A4 /* Pods-Beiwe.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BUNDLE_ID_SUFFIX = debug;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = G7SF52LNB8;
+				DEVELOPMENT_TEAM = WRY9L72ZUW;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Beiwe/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.rocketfarmstudios.beiwe.debug;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zagaran.beiwe.jj;
 				PRODUCT_NAME = "$(TARGET_NAME)${TARGET_NAME_SUFFIX}";
-				PROVISIONING_PROFILE = "5a46d0b3-ef70-4afe-8cdb-a59d454b8e34";
-				PROVISIONING_PROFILE_SPECIFIER = "New Beiwe pp";
+				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Beiwe-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.0;
@@ -906,19 +907,22 @@
 		};
 		83F98C4A1C923C3600E0B64B /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 36EDF07B2D8E6AF15C179925 /* Pods-Beiwe.release.xcconfig */;
+			baseConfigurationReference = D16F300F4AD663617AEF4916 /* Pods-Beiwe.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BUNDLE_ID_SUFFIX = "";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = 6M52R5C7FT;
+				DEVELOPMENT_TEAM = WRY9L72ZUW;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Beiwe/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = lab.onnela.beiwe.ios;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zagaran.beiwe.jj;
 				PRODUCT_NAME = "$(TARGET_NAME)${TARGET_NAME_SUFFIX}";
-				PROVISIONING_PROFILE = "2e83479d-5eb9-48c4-8c61-a4cb45836653";
-				PROVISIONING_PROFILE_SPECIFIER = "Beiwe Provisioning Profile";
+				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Beiwe-Bridging-Header.h";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -983,17 +987,22 @@
 		};
 		83F98C4C1C9243A800E0B64B /* TestFlight Internal */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D4903A730C06BC2993F77F77 /* Pods-Beiwe.testflight internal.xcconfig */;
+			baseConfigurationReference = 6BE1CD8AB3101933EE9A89CE /* Pods-Beiwe.testflight internal.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BUNDLE_ID_SUFFIX = tfint;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = WRY9L72ZUW;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Beiwe/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				ONLY_ACTIVE_ARCH = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = com.rocketfarmstudios.beiwe.tint;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zagaran.beiwe.jj;
 				PRODUCT_NAME = "$(TARGET_NAME)${TARGET_NAME_SUFFIX}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Beiwe-Bridging-Header.h";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -1058,17 +1067,22 @@
 		};
 		83F98C4E1C9243BB00E0B64B /* TestFlight External */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 38F9762E5747F220806BB64A /* Pods-Beiwe.testflight external.xcconfig */;
+			baseConfigurationReference = F69132CC13AD41995B997EEB /* Pods-Beiwe.testflight external.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BUNDLE_ID_SUFFIX = tfext;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = WRY9L72ZUW;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Beiwe/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				ONLY_ACTIVE_ARCH = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = com.rocketfarmstudios.beiwe.text;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zagaran.beiwe.jj;
 				PRODUCT_NAME = "$(TARGET_NAME)${TARGET_NAME_SUFFIX}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Beiwe-Bridging-Header.h";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -1101,8 +1115,8 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "iPhone Distribution: Harvard University (UHX83HR959)";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution: Harvard University (UHX83HR959)";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_BITCODE = NO;
@@ -1128,19 +1142,22 @@
 		};
 		83FCB39C1F99485B0039366A /* Harvard */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FB6A8DD0D5BBD86CEBD12A4A /* Pods-Beiwe.harvard.xcconfig */;
+			baseConfigurationReference = 94A69B255EC17D5859DD273C /* Pods-Beiwe.harvard.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BUNDLE_ID_SUFFIX = "";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = UHX83HR959;
+				DEVELOPMENT_TEAM = WRY9L72ZUW;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Beiwe/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = harvard.lab.onnela.beiwe.ios;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zagaran.beiwe.jj;
 				PRODUCT_NAME = Beiwe2;
-				PROVISIONING_PROFILE = "29cf203d-4ae5-4bca-b10e-8535d61933e8";
-				PROVISIONING_PROFILE_SPECIFIER = "Beiwe2 app";
+				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Beiwe-Bridging-Header.h";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = 1;

--- a/Beiwe.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Beiwe.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Beiwe.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Beiwe.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
+	<true/>
+</dict>
+</plist>

--- a/Beiwe.xcodeproj/xcshareddata/xcschemes/Beiwe Debug.xcscheme
+++ b/Beiwe.xcodeproj/xcshareddata/xcschemes/Beiwe Debug.xcscheme
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -46,7 +45,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Beiwe.xcodeproj/xcshareddata/xcschemes/Beiwe.xcscheme
+++ b/Beiwe.xcodeproj/xcshareddata/xcschemes/Beiwe.xcscheme
@@ -26,7 +26,6 @@
       buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -43,10 +42,9 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Beiwe.xcodeproj/xcshareddata/xcschemes/Zagaran.xcscheme
+++ b/Beiwe.xcodeproj/xcshareddata/xcschemes/Zagaran.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "1010"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Harvard"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
@@ -42,7 +42,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Harvard"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -65,7 +65,7 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Harvard"
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
@@ -82,10 +82,10 @@
       </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "Harvard">
+      buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Harvard"
+      buildConfiguration = "Release"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/Beiwe.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Beiwe.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Beiwe/Controllers/RegisterViewController.swift
+++ b/Beiwe/Controllers/RegisterViewController.swift
@@ -134,7 +134,11 @@ class RegisterViewController: FormViewController {
                                 let study = Study(patientPhone: phoneNumber, patientId: patientId, studySettings: studySettings, apiUrl: customApiUrl);
                                 study.clinicianPhoneNumber = clinicianPhone
                                 study.raPhoneNumber = raPhone
-                                return StudyManager.sharedInstance.purgeStudies().then {_ in 
+                                if studySettings.fuzzGps {
+                                    study.fuzzGpsLatitudeOffset = self._generateLatitudeOffset()
+                                    study.fuzzGpsLongitudeOffset = self._generateLongitudeOffset()
+                                }
+                                return StudyManager.sharedInstance.purgeStudies().then {_ in
                                     return self.db.save(study)
                                 }
                             }.then { _ -> Promise<Bool> in
@@ -202,6 +206,28 @@ class RegisterViewController: FormViewController {
         // Dispose of any resources that can be recreated.
     }
     
+    
+    /*
+     Generates a random offset between -1 and 1 (thats not between -0.2 and 0.2)
+    */
+    func _generateLatitudeOffset() -> Double {
+        var ran = Double.random(in: -1...1)
+        while(ran <= 0.2 && ran >= -0.2) {
+            ran = Double.random(in: -1...1)
+        }
+        return ran
+    }
+    
+    /*
+     Generates a random offset between -180 and 180 (thats not between -10 and 10)
+    */
+    func _generateLongitudeOffset() -> Double {
+        var ran = Double.random(in: -180...180)
+        while(ran <= 10 && ran >= -10) {
+            ran = Double.random(in: -180...180)
+        }
+        return ran
+    }
 
     /*
     // MARK: - Navigation

--- a/Beiwe/Managers/ConsentManager.swift
+++ b/Beiwe/Managers/ConsentManager.swift
@@ -24,10 +24,10 @@ class WaitForPermissionsRule : ORKStepNavigationRule {
     init(nextTask: @escaping ((_ taskResult: ORKTaskResult) -> String)) {
         self.nextTask = nextTask
 
-        super.init(coder: NSCoder())!
+        super.init(coder: NSCoder())
     }
     
-    required init?(coder aDecoder: NSCoder) {
+    required init(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     override func identifierForDestinationStep(with taskResult: ORKTaskResult)  -> String {

--- a/Beiwe/Managers/StudyManager.swift
+++ b/Beiwe/Managers/StudyManager.swift
@@ -92,6 +92,12 @@ class StudyManager {
         /* Move non current files out.  Probably not necessary, would happen later anyway */
         DataStorageManager.sharedInstance.prepareForUpload();
         gpsManager = GPSManager();
+        
+        // Check if gps fuzzing is enabled for currentStudy
+        gpsManager?.enableGpsFuzzing = studySettings.fuzzGps ? true : false
+        gpsManager?.fuzzGpsLatitudeOffset = (currentStudy?.fuzzGpsLatitudeOffset)!
+        gpsManager?.fuzzGpsLongitudeOffset = (currentStudy?.fuzzGpsLongitudeOffset)!
+        
         gpsManager!.addDataService(AppEventManager.sharedInstance)
         if (studySettings.gps && studySettings.gpsOnDurationSeconds > 0) {
             gpsManager!.addDataService(studySettings.gpsOnDurationSeconds, off: studySettings.gpsOffDurationSeconds, handler: gpsManager!)

--- a/Beiwe/Models/Study.swift
+++ b/Beiwe/Models/Study.swift
@@ -29,6 +29,8 @@ class Study : ReclineObject {
     var submittedAudioSurveys: Int = 0;
     var submittedTrackingSurveys: Int = 0;
     var customApiUrl: String?;
+    var fuzzGpsLongitudeOffset: Double = 0.0;
+    var fuzzGpsLatitudeOffset: Double = 0.0;
 
     var surveys: [Survey] = [ ];
     var activeSurveys: [String:ActiveSurvey] = [:]
@@ -74,7 +76,8 @@ class Study : ReclineObject {
         missedUploadCheck <- map["missedUploadCheck"]
         lastUploadSuccess <- map["lastUploadSuccess"]
         customApiUrl <- map["customApiUrl"]
-
+        fuzzGpsLongitudeOffset <- map["fuzzGpsLongitudeOffset"]
+        fuzzGpsLatitudeOffset <- map["fuzzGpsLatitudeOffset"]
     }
 
 }

--- a/Beiwe/Models/StudySettings.swift
+++ b/Beiwe/Models/StudySettings.swift
@@ -96,6 +96,7 @@ struct StudySettings : Mappable {
     var reachability = false;
     var uploadOverCellular = false;
     var consentSections: [String:ConsentSection] = [:];
+    var fuzzGps = false;
 
     init?(map: Map) {
 
@@ -141,6 +142,7 @@ struct StudySettings : Mappable {
         reachability                   <- map["device_settings.reachability"];
         consentSections                <- map["device_settings.consent_sections"]
         uploadOverCellular             <- map["device_settings.allow_upload_over_cellular_data"]
+        fuzzGps                        <- map["device_settings.use_gps_fuzzing"]
     }
     
 }

--- a/Beiwe/RK/BWSkipStepNavigationRule.swift
+++ b/Beiwe/RK/BWSkipStepNavigationRule.swift
@@ -81,11 +81,11 @@ class BWSkipStepNavigationRule : ORKSkipStepNavigationRule {
         }();
 
     convenience init(displayIf: [String:AnyObject]) {
-        self.init(coder: NSCoder())!;
+        self.init(coder: NSCoder());
         self.displayIf = displayIf;
     }
 
-    required init?(coder: NSCoder) {
+    required init(coder: NSCoder) {
         super.init(coder: coder);
     }
     

--- a/Beiwe/Util/Crypto.swift
+++ b/Beiwe/Util/Crypto.swift
@@ -31,9 +31,9 @@ class Crypto {
 
     func randomBytes(_ length: Int) -> Data? {
         var data = Data(count: length)
-        let result = data.withUnsafeMutableBytes {
+        let result = data.withUnsafeMutableBytes { [count=data.count]
             (mutableBytes: UnsafeMutablePointer<UInt8>) -> Int32 in
-            SecRandomCopyBytes(kSecRandomDefault, data.count, mutableBytes)
+            SecRandomCopyBytes(kSecRandomDefault, count, mutableBytes)
         }
 
         if (result == errSecSuccess) {

--- a/Podfile
+++ b/Podfile
@@ -1,24 +1,25 @@
-platform :ios, '9.0'
+platform :ios, '9.1'
 
 target 'Beiwe' do
   use_frameworks!
   pod 'Crashlytics', '~> 3.4'
   pod 'KeychainSwift', '~> 8.0'
-  pod "PromiseKit", "~> 4.4"
+  pod "PromiseKit"
   pod 'Alamofire', '~> 4.5'
-  pod 'ObjectMapper', :git => 'https://github.com/Hearst-DD/ObjectMapper.git', :branch => 'swift-4'
-  pod 'Eureka', :git => 'https://github.com/xmartlabs/Eureka.git', :branch => 'feature/Xcode9-Swift4'
+  pod 'ObjectMapper', :git => 'https://github.com/Hearst-DD/ObjectMapper.git', :branch => 'master'
+  pod 'Eureka'
   pod 'SwiftValidator', :git => 'https://github.com/jpotts18/SwiftValidator.git', :branch => 'master'
   pod "PKHUD", :git => 'https://github.com/pkluz/PKHUD.git', :branch => 'swift4'
-  pod 'IDZSwiftCommonCrypto', '~> 0.9'
+  pod 'IDZSwiftCommonCrypto'
   pod 'couchbase-lite-ios'
-  pod 'ResearchKit', :git => 'https://github.com/ResearchKit/ResearchKit.git'
-  pod 'ReachabilitySwift'
+  pod 'ResearchKit'
+  pod 'ReachabilitySwift', '~>3'
   pod 'EmitterKit', '~> 5.1'
-  pod 'PermissionScope', :git => 'git@github.com:RocketFarm/PermissionScope.git', :branch => 'master'
+  pod 'PermissionScope', :git => 'https://github.com/RocketFarm/PermissionScope.git', :branch => 'master'
   pod 'Hakuba', :git => 'https://github.com/eskizyen/Hakuba.git', :branch => 'Swift3'
-  pod 'XLActionController', :git => 'https://github.com/xmartlabs/XLActionController.git', :branch => 'swift4'
+  pod 'XLActionController'
   pod 'XCGLogger', '~> 5.0.1'
+
 end
 
 post_install do |installer|

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,135 +1,135 @@
 PODS:
-  - Alamofire (4.5.1)
-  - couchbase-lite-ios (1.3.1):
-    - couchbase-lite-ios/SQLite (= 1.3.1)
-  - couchbase-lite-ios/SQLite (1.3.1)
-  - Crashlytics (3.8.3):
-    - Fabric (~> 1.6.3)
-  - EmitterKit (5.1.0)
-  - Eureka (3.0.0)
-  - Fabric (1.6.11)
+  - Alamofire (4.7.2)
+  - couchbase-lite-ios (1.4.1):
+    - couchbase-lite-ios/SQLite (= 1.4.1)
+  - couchbase-lite-ios/SQLite (1.4.1)
+  - Crashlytics (3.10.2):
+    - Fabric (~> 1.7.7)
+  - EmitterKit (5.2.0)
+  - Eureka (4.1.1)
+  - Fabric (1.7.7)
   - Hakuba (2.1.1)
-  - IDZSwiftCommonCrypto (0.9.2)
-  - KeychainSwift (8.0.2)
+  - IDZSwiftCommonCrypto (0.10.0)
+  - KeychainSwift (8.0.3)
   - ObjcExceptionBridging (1.0.1):
     - ObjcExceptionBridging/ObjcExceptionBridging (= 1.0.1)
   - ObjcExceptionBridging/ObjcExceptionBridging (1.0.1)
-  - ObjectMapper (2.3.0)
+  - ObjectMapper (3.4.0)
   - PermissionScope (1.1.1)
   - PKHUD (4.2.3)
-  - PromiseKit (4.4.0):
-    - PromiseKit/Foundation (= 4.4.0)
-    - PromiseKit/QuartzCore (= 4.4.0)
-    - PromiseKit/UIKit (= 4.4.0)
-  - PromiseKit/CorePromise (4.4.0)
-  - PromiseKit/Foundation (4.4.0):
+  - PromiseKit (4.5.2):
+    - PromiseKit/Foundation (= 4.5.2)
+    - PromiseKit/QuartzCore (= 4.5.2)
+    - PromiseKit/UIKit (= 4.5.2)
+  - PromiseKit/CorePromise (4.5.2)
+  - PromiseKit/Foundation (4.5.2):
     - PromiseKit/CorePromise
-  - PromiseKit/QuartzCore (4.4.0):
+  - PromiseKit/QuartzCore (4.5.2):
     - PromiseKit/CorePromise
-  - PromiseKit/UIKit (4.4.0):
+  - PromiseKit/UIKit (4.5.2):
     - PromiseKit/CorePromise
   - ReachabilitySwift (3)
-  - ResearchKit (1.4.1)
+  - ResearchKit (1.5.2)
   - SwiftValidator (4.0.0)
-  - XCGLogger (5.0.1):
-    - XCGLogger/Core (= 5.0.1)
-  - XCGLogger/Core (5.0.1):
+  - XCGLogger (5.0.5):
+    - XCGLogger/Core (= 5.0.5)
+  - XCGLogger/Core (5.0.5):
     - ObjcExceptionBridging
-  - XLActionController (3.0.1):
-    - XLActionController/Core (= 3.0.1)
-  - XLActionController/Core (3.0.1)
+  - XLActionController (4.0.1):
+    - XLActionController/Core (= 4.0.1)
+  - XLActionController/Core (4.0.1)
 
 DEPENDENCIES:
   - Alamofire (~> 4.5)
   - couchbase-lite-ios
   - Crashlytics (~> 3.4)
   - EmitterKit (~> 5.1)
-  - Eureka (from `https://github.com/xmartlabs/Eureka.git`, branch `feature/Xcode9-Swift4`)
+  - Eureka
   - Hakuba (from `https://github.com/eskizyen/Hakuba.git`, branch `Swift3`)
-  - IDZSwiftCommonCrypto (~> 0.9)
+  - IDZSwiftCommonCrypto
   - KeychainSwift (~> 8.0)
-  - ObjectMapper (from `https://github.com/Hearst-DD/ObjectMapper.git`, branch `swift-4`)
-  - PermissionScope (from `git@github.com:RocketFarm/PermissionScope.git`, branch `master`)
+  - ObjectMapper (from `https://github.com/Hearst-DD/ObjectMapper.git`, branch `master`)
+  - PermissionScope (from `https://github.com/RocketFarm/PermissionScope.git`, branch `master`)
   - PKHUD (from `https://github.com/pkluz/PKHUD.git`, branch `swift4`)
-  - PromiseKit (~> 4.4)
-  - ReachabilitySwift
-  - ResearchKit (from `https://github.com/ResearchKit/ResearchKit.git`)
+  - PromiseKit
+  - ReachabilitySwift (~> 3)
+  - ResearchKit
   - SwiftValidator (from `https://github.com/jpotts18/SwiftValidator.git`, branch `master`)
   - XCGLogger (~> 5.0.1)
-  - XLActionController (from `https://github.com/xmartlabs/XLActionController.git`, branch `swift4`)
+  - XLActionController
+
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - Alamofire
+    - couchbase-lite-ios
+    - Crashlytics
+    - EmitterKit
+    - Eureka
+    - Fabric
+    - IDZSwiftCommonCrypto
+    - KeychainSwift
+    - ObjcExceptionBridging
+    - PromiseKit
+    - ReachabilitySwift
+    - ResearchKit
+    - XCGLogger
+    - XLActionController
 
 EXTERNAL SOURCES:
-  Eureka:
-    :branch: feature/Xcode9-Swift4
-    :git: https://github.com/xmartlabs/Eureka.git
   Hakuba:
     :branch: Swift3
     :git: https://github.com/eskizyen/Hakuba.git
   ObjectMapper:
-    :branch: swift-4
+    :branch: master
     :git: https://github.com/Hearst-DD/ObjectMapper.git
   PermissionScope:
     :branch: master
-    :git: git@github.com:RocketFarm/PermissionScope.git
+    :git: https://github.com/RocketFarm/PermissionScope.git
   PKHUD:
     :branch: swift4
     :git: https://github.com/pkluz/PKHUD.git
-  ResearchKit:
-    :git: https://github.com/ResearchKit/ResearchKit.git
   SwiftValidator:
     :branch: master
     :git: https://github.com/jpotts18/SwiftValidator.git
-  XLActionController:
-    :branch: swift4
-    :git: https://github.com/xmartlabs/XLActionController.git
 
 CHECKOUT OPTIONS:
-  Eureka:
-    :commit: 142d80535b27b3634ac5a38514bde948b8ed42de
-    :git: https://github.com/xmartlabs/Eureka.git
   Hakuba:
     :commit: 9d748747369671e162b4f088402eacbfa997121a
     :git: https://github.com/eskizyen/Hakuba.git
   ObjectMapper:
-    :commit: ae333e622321193e223f343eb981662bccc00b76
+    :commit: 646f305426e8f3b87d61b9eb9745efbf296ede6f
     :git: https://github.com/Hearst-DD/ObjectMapper.git
   PermissionScope:
     :commit: fa44f6ad2d75c6320e3530300f79ce0254f189e2
-    :git: git@github.com:RocketFarm/PermissionScope.git
+    :git: https://github.com/RocketFarm/PermissionScope.git
   PKHUD:
     :commit: 4d8fbf70ae912dd72280cde0a5c1440ada9a7306
     :git: https://github.com/pkluz/PKHUD.git
-  ResearchKit:
-    :commit: e4918e28bd484f5110f01dc1d1b4babe0f098477
-    :git: https://github.com/ResearchKit/ResearchKit.git
   SwiftValidator:
-    :commit: 6cff6cac3e02a617f7cf11323e18526a117d5673
+    :commit: ba27b0e501bf542b5c1a97bed8f706d12fb2d4f4
     :git: https://github.com/jpotts18/SwiftValidator.git
-  XLActionController:
-    :commit: 4664deea6953949db403c35794eb9c89362d6dc9
-    :git: https://github.com/xmartlabs/XLActionController.git
 
 SPEC CHECKSUMS:
-  Alamofire: 2d95912bf4c34f164fdfc335872e8c312acaea4a
-  couchbase-lite-ios: e4672e9c623e31584602c0300c299c363acebb05
-  Crashlytics: 2b6dbe138a42395577cfa73dfa1aa7248cadf39e
-  EmitterKit: 278276e05f9c00482fad8ca2e8e54ad5429e8ceb
-  Eureka: 5b9418d7bfdc21ca977d69d124a6409f3e9af2c7
-  Fabric: 5911403591946b8228ab1c51d98f1d7137e863c6
+  Alamofire: e4fa87002c137ba2d8d634d2c51fabcda0d5c223
+  couchbase-lite-ios: 7c875538a0fc55a7e9744edb4e89c23737686230
+  Crashlytics: 0360624eea1c978a743feddb2fb1ef8b37fb7a0d
+  EmitterKit: c3948fb82c4cdb11d9019c13d374e7f22188537e
+  Eureka: b88fb930e42c79f8c03c373d0fcdc28c1d6c50ed
+  Fabric: bda89e242bce1b7b8ab264248cf3407774ce0095
   Hakuba: bc5a0422290d086c33a6424a26dd58c1a1136e94
-  IDZSwiftCommonCrypto: 671867eabeeee3a2c2395c2152fe3d4349ffc062
-  KeychainSwift: 213db04dfe7244988e61f77c72a2afb2f775954a
+  IDZSwiftCommonCrypto: 4eef2c46e262dfbcbc1fd76365e066336680ad7d
+  KeychainSwift: be9554c0e5f4b1686c775930dc5c6bd9396992ed
   ObjcExceptionBridging: c30e00eb3700467e695faeea30e26e18bd445001
-  ObjectMapper: 071f9e47ae0ac75e3b445a4f3510b6a94afef52d
+  ObjectMapper: c4934ba1889f325066c736861592f48008a7dfde
   PermissionScope: a30c16e015779ba27c97c124e7539e27b5829de2
   PKHUD: 351011b853e6b942e7ee8ad335864cc84c787241
-  PromiseKit: ecf5fe92275d57ee77c9ede858af47a162e9b97e
+  PromiseKit: 743e497a5f505a470d3bbbf4ce0663c1268af0a4
   ReachabilitySwift: f5b9bb30a0777fac8f09ce8b067e32faeb29bb64
-  ResearchKit: e308eb4b980784bd2bda6f3716325fa929c000c0
+  ResearchKit: a5770681dd61afddd3d1f24d232b9abf00cba454
   SwiftValidator: 25ded5ca1f10c05adf57f6ac82a72d28ac8d91af
-  XCGLogger: 0b43697155d41e4a1b15fc776f319c2141646b09
-  XLActionController: 57fe0ce1642e2eed971b188b490762345fdbf963
+  XCGLogger: 49bceee6dc0c738eae5d6454fdbf800d62256b74
+  XLActionController: 007868251c0eed70d649d06c1625259b73b3a600
 
-PODFILE CHECKSUM: ad318c4909dd69b6371437bd0dc185e39295ae1b
+PODFILE CHECKSUM: 6ad29cac26f6d248dd5bb955f7e8415cb37541c4
 
-COCOAPODS: 1.2.0
+COCOAPODS: 1.5.3


### PR DESCRIPTION
Fuzzes/Anonymizes GPS coordinates for studies that have the `fuzz_gps` set to `True` in Device Settings.

If the app enrolls in a study where `fuzz_gps` is `True`, then during registration it generates a random latitude offset (between -1 degree and +1 degree), and a random longitude offset (between -180 degrees and +180 degrees).  The app then adds these constant offsets to all latitude/longitude measurements.  The offsets are unique to each phone and are never sent to the server.  This means that researchers still get the complete GPS trace, but it's shifted by some unknown amount, which makes the data less personally identifiable.

If the app enrolls in a study where `fuzz_gps` is `False`, or where `fuzz_gps` is nonexistent (on an older Beiwe deployment), then it records the true latitude/longitude coordinates, as before.