### PR TITLE
When sanitizing data, use periods instead of semicolons

### DIFF
--- a/Beiwe/Managers/DataStorageManager.swift
+++ b/Beiwe/Managers/DataStorageManager.swift
@@ -300,7 +300,7 @@ class DataStorage {
             if (self.sanitize) {
                 sanitizedData = [];
                 for str in data {
-                    sanitizedData.append(str.replacingOccurrences(of: ",", with: ";").replacingOccurrences(of: "[\t\n\r]", with: " ", options: .regularExpression))
+                    sanitizedData.append(str.replacingOccurrences(of: ",", with: ".").replacingOccurrences(of: "[\t\n\r]", with: " ", options: .regularExpression))
                 }
             } else {
                 sanitizedData = data;


### PR DESCRIPTION
Question answer options are separated using semicolons, so using semicolons to sanitize commas causes a bug further down the line in analysis: [https://github.com/onnela-lab/beiwe-backend/issues/53](https://github.com/onnela-lab/beiwe-backend/issues/53)