### PR TITLE
Allow International Phone Numbers

### DIFF
--- a/Beiwe/Base.lproj/Localizable.strings
+++ b/Beiwe/Base.lproj/Localizable.strings
@@ -20,9 +20,9 @@
 "registration_confirm_new_password_label" = "Confirm Password:";
 "registration_confirm_new_password_hint" = "Confirm Password";
 "phone_number_entry_your_clinician_label" = "Primary Researcher Phone:";
-"phone_number_entry_your_clinician_hint" = "10 digit number";
+"phone_number_entry_your_clinician_hint" = "8-15 digits";
 "phone_number_entry_research_assistant_label" = "Research Asst. Phone:";
-"phone_number_entry_research_assistant_hint" = "10 digit number";
+"phone_number_entry_research_assistant_hint" = "8-15 digits";
 "registration_submit" = "Register";
 "http_message_server_not_found" = "The server you are trying to register with is currently unavailable, or you have entered an incorrect server address.  Please verify the server address.";
 "couldnt_register" = "Registration failed";

--- a/Beiwe/Controllers/RegisterViewController.swift
+++ b/Beiwe/Controllers/RegisterViewController.swift
@@ -85,14 +85,14 @@ class RegisterViewController: FormViewController {
             <<< SVSimplePhoneRow("clinicianPhone") {
                 $0.title = NSLocalizedString("phone_number_entry_your_clinician_label", comment: "")
                 $0.placeholder = NSLocalizedString("phone_number_entry_your_clinician_hint", comment: "")
-                $0.customRules = [RequiredRule(), PhoneNumberRule()]
+                $0.customRules = [RequiredRule(), MinLengthRule(length: 8), MaxLengthRule(length: 15), FloatRule()]
                 $0.autoValidation = autoValidation
 
             }
             <<< SVSimplePhoneRow("raPhone") {
                 $0.title = NSLocalizedString("phone_number_entry_research_assistant_label", comment: "")
                 $0.placeholder = NSLocalizedString("phone_number_entry_research_assistant_hint", comment: "")
-                $0.customRules = [RequiredRule(), PhoneNumberRule()]
+                $0.customRules = [RequiredRule(), MinLengthRule(length: 8), MaxLengthRule(length: 15), FloatRule()]
                 $0.autoValidation = autoValidation
 
             }


### PR DESCRIPTION
Change from only allowing 10-digit phone numbers to allowing any phone numbers between 8 and 15 digits

This works as expected on the emulator on my machine. 