### PR TITLE
Log permission_changed events for location, notification, and Background App Refresh

### DIFF
--- a/Beiwe/API/ApiManager.swift
+++ b/Beiwe/API/ApiManager.swift
@@ -94,14 +94,7 @@ class ApiManager {
         // Location services configuration
         device_status_report["location_services_enabled"] = Ephemerals.locationServicesEnabledDescription
         device_status_report["location_significant_change_monitoring_enabled"] = Ephemerals.significantLocationChangeMonitoringAvailable
-        device_status_report["location_permission"] = switch CLLocationManager.authorizationStatus() {
-        case .notDetermined: "not_determined"
-        case .restricted: "restricted"
-        case .denied: "denied"
-        case .authorizedAlways: "authorized_always"
-        case .authorizedWhenInUse: "authorized_when_in_use"
-        @unknown default: "unknown: '\(CLLocationManager.authorizationStatus().rawValue)'"
-        }
+        device_status_report["location_permission"] = locationPermissionDescription()
         
         // Ephemerals are items that for one reason or another are stored on and not perisistent.
         

--- a/Beiwe/AppDelegate.swift
+++ b/Beiwe/AppDelegate.swift
@@ -375,6 +375,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CLLocationManagerDelegate
 
     func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+        // NOTE: this is best-effort. iOS only calls applicationWillTerminate when the app is in the
+        // foreground (or is a suspended app being cleanly terminated); a force-quit from the app switcher
+        // while suspended, a jetsam kill, a crash, or a device shutdown will NOT hit this function, so
+        // the "terminate" app log event below (and lastApplicationWillTerminate) are not a reliable
+        // record of every app death. Use the launch event of the next session to detect those cases.
         print("applicationWillTerminate")
         if let study = self.currentStudy {
             study.lastApplicationWillTerminate = self.currentTimestamp

--- a/Beiwe/AppDelegate.swift
+++ b/Beiwe/AppDelegate.swift
@@ -202,9 +202,35 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CLLocationManagerDelegate
     func deviceInfoUpdateLoop() {
         Ephemerals.lastAppStart = self.currentTimestamp
         
-        // This takes an amount of time to run / must be run ~asynchronously
+        // locationServicesEnabledDescription and notification_permission are device info datapoints taht need to be checked on periiodically
+        // because they require async calls to get their values, and we can't wait on them every time we do a network request.
+        Ephemerals.locationServicesEnabledDescription = CLLocationManager.locationServicesEnabled().description
+        Ephemerals.significantLocationChangeMonitoringAvailable = CLLocationManager.significantLocationChangeMonitoringAvailable().description
+        
+        self.updatePermissionStates()
+        
+        // print("UIApplication.shared.backgroundTimeRemaining:", UIApplication.shared.backgroundTimeRemaining)
+        updateBackgroundTasksCount()
+        
+        BACKGROUND_DEVICE_INFO_QUEUE.asyncAfter(deadline: .now() + 60, execute: self.deviceInfoUpdateLoop)
+    }
+    
+    /// Reads the current state of the permissions/settings that data collection depends on (location permission,
+    /// notification permission, Background App Refresh), stores them on Ephemerals (for the device status report),
+    /// and writes a "permission_changed" app log event for any that differ from the last known value.
+    /// Runs once a minute from deviceInfoUpdateLoop, every time the app becomes active, and from the location
+    /// authorization callbacks (location is the only one of these with a native change callback; the other two
+    /// can only be detected by polling, and this app doesn't persist last-known values across launches so the
+    /// first read after every launch establishes the baseline and is not logged as a change).
+    func updatePermissionStates() {
+        // location permission
+        let location_permission = locationPermissionDescription()
+        self.logPermissionChange("location", previous: Ephemerals.location_permission, current: location_permission)
+        Ephemerals.location_permission = location_permission
+        
+        // notification permission - This takes an amount of time to run / must be run ~asynchronously
         UNUserNotificationCenter.current().getNotificationSettings(completionHandler: { settings in
-            Ephemerals.notification_permission = switch settings.authorizationStatus {
+            let notification_permission = switch settings.authorizationStatus {
             case .notDetermined: "not_determined"
             case .denied: "denied"
             case .authorized: "authorized"
@@ -212,26 +238,32 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CLLocationManagerDelegate
             case .ephemeral: "ephemeral"
             @unknown default: "unknown: '\(settings.authorizationStatus.rawValue)'"
             }
+            self.logPermissionChange("notification", previous: Ephemerals.notification_permission, current: notification_permission)
+            Ephemerals.notification_permission = notification_permission
         })
-
-        // locationServicesEnabledDescription and notification_permission are device info datapoints taht need to be checked on periiodically
-        // because they require async calls to get their values, and we can't wait on them every time we do a network request.
-        Ephemerals.locationServicesEnabledDescription = CLLocationManager.locationServicesEnabled().description
-        Ephemerals.significantLocationChangeMonitoringAvailable = CLLocationManager.significantLocationChangeMonitoringAvailable().description
         
         // backgroundRefreshStatus needs to be run on the main thread, but we can do this asynchronously somehow? and that's better? hunh?
         DispatchQueue.main.async {
-            Ephemerals.backgroundRefreshStatus = switch UIApplication.shared.backgroundRefreshStatus {
+            let backgroundRefreshStatus = switch UIApplication.shared.backgroundRefreshStatus {
             case .available: "available"
             case .denied: "denied"
             case .restricted: "restricted"
             @unknown default: "unknown: '\(UIApplication.shared.backgroundRefreshStatus.rawValue)'"
             }
+            self.logPermissionChange("background_app_refresh", previous: Ephemerals.backgroundRefreshStatus, current: backgroundRefreshStatus)
+            Ephemerals.backgroundRefreshStatus = backgroundRefreshStatus
         }
-        // print("UIApplication.shared.backgroundTimeRemaining:", UIApplication.shared.backgroundTimeRemaining)
-        updateBackgroundTasksCount()
-        
-        BACKGROUND_DEVICE_INFO_QUEUE.asyncAfter(deadline: .now() + 60, execute: self.deviceInfoUpdateLoop)
+    }
+    
+    /// Writes a permission_changed event to the app log if a permission's value differs from its last known value.
+    /// The first population after app launch (from the NOT_POPULATED sentinel) is the baseline, not a change.
+    func logPermissionChange(_ name: String, previous: String, current: String) {
+        if previous == current || previous == Ephemerals.NOT_POPULATED {
+            return
+        }
+        print("permission changed - \(name): \(previous) -> \(current)")
+        AppEventManager.sharedInstance.logAppEvent(
+            event: "permission_changed", msg: "\(name): \(previous) -> \(current)", d1: name, d2: previous, d3: current)
     }
     
     /// anything that depends on app state at initialization time needs to go after this has run
@@ -375,6 +407,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CLLocationManagerDelegate
         print("applicationDidBecomeActive")
         Ephemerals.lastApplicationDidBecomeActive = self.currentTimestamp
         AppEventManager.sharedInstance.logAppEvent(event: "foreground", msg: "Application entered foreground")
+        
+        // the participant may have changed a permission in Settings.app while we were in the background.
+        self.updatePermissionStates()
 
         // Send FCM Token everytime the app launches
         if ApiManager.sharedInstance.patientId != "" /* && FirebaseApp.app() != nil*/ {
@@ -416,7 +451,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CLLocationManagerDelegate
     ////////////////////////////////////////////////////////////////////////////////////////////////
 
     /// this function gets called when CLAuthorization status changes
+    /// (only while this AppDelegate is the delegate of self.locManager, which is set up in ConsentManager,
+    /// the GPSManager has its own CLLocationManager and gets its own copy of this callback.)
     func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+        self.updatePermissionStates() // logs a permission_changed event if it actually changed
         switch status {
         case .notDetermined:
             // If status has not yet been determied, ask for authorization

--- a/Beiwe/Common.swift
+++ b/Beiwe/Common.swift
@@ -1,3 +1,4 @@
+import CoreLocation
 import Sentry
 import XCGLogger
 
@@ -148,6 +149,19 @@ func smartformat(_ unix_timestamp: TimeInterval) -> String {
 
 func timestampString() -> String {
     return dateFormat(Date())
+}
+
+/// the current location permission as a string, can be one of not_determined, restricted, denied,
+/// authorized_always, or authorized_when_in_use. (used in the device status report and the app log)
+func locationPermissionDescription() -> String {
+    return switch CLLocationManager.authorizationStatus() {
+    case .notDetermined: "not_determined"
+    case .restricted: "restricted"
+    case .denied: "denied"
+    case .authorizedAlways: "authorized_always"
+    case .authorizedWhenInUse: "authorized_when_in_use"
+    @unknown default: "unknown: '\(CLLocationManager.authorizationStatus().rawValue)'"
+    }
 }
 
 /// converts the iso time string format to a TimeInterval (integer)

--- a/Beiwe/Constants.swift
+++ b/Beiwe/Constants.swift
@@ -64,11 +64,14 @@ let GYRO_CACHE_SIZE = 100
 let MAGNETOMETER_CACHE_SIZE = 100
 
 struct Ephemerals {
+    static let NOT_POPULATED = "not populated, this is an app bug"
+    
     // device info statuses
-    static var notification_permission = "not populated, this is an app bug"
-    static var locationServicesEnabledDescription = "not populated, this is an app bug"
-    static var significantLocationChangeMonitoringAvailable = "not populated, this is an app bug"
-    static var backgroundRefreshStatus = "not populated, this is an app bug"
+    static var notification_permission = NOT_POPULATED
+    static var location_permission = NOT_POPULATED
+    static var locationServicesEnabledDescription = NOT_POPULATED
+    static var significantLocationChangeMonitoringAvailable = NOT_POPULATED
+    static var backgroundRefreshStatus = NOT_POPULATED
     static var transition_count = 0
     static var background_task_count = "(not populated yet?)"
     static var start_last_upload = "not populated"

--- a/Beiwe/Managers/GPSManager.swift
+++ b/Beiwe/Managers/GPSManager.swift
@@ -163,6 +163,13 @@ class GPSManager: NSObject, CLLocationManagerDelegate, DataServiceProtocol {
         AppEventManager.sharedInstance.logAppEvent(event: "gps \"FinishDeferredUpdatesWithError\" error message received", d1: error_message)
     }
     
+    /// Invoked when either the authorizationStatus or accuracyAuthorization properties change (iOS 14+),
+    /// also fires once when the delegate is assigned. Defers to the AppDelegate's permission tracking, which
+    /// writes a permission_changed app log event only when the value actually differs from the last known one.
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        AppDelegate.sharedInstance().updatePermissionStates()
+    }
+    
     /*  locationManager:didFailWithError:
     Invoked when an error has occurred. Error types are defined in "CLError.h". */
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {


### PR DESCRIPTION
Adds a `permission_changed` event to the ios_log stream so adherence and data-completeness analysis can line up gaps in a participant's data with the moment they revoked a permission.

## What gets logged

Three things are tracked. Location permission, notification permission, and Background App Refresh. When any of them differs from the last known value the app writes one row with the same helper and columns every other ios_log event already uses.

| column | value |
|---|---|
| event | `permission_changed` |
| msg | `location: authorized_when_in_use -> denied` |
| d1 | permission name (`location`, `notification`, `background_app_refresh`) |
| d2 | previous value |
| d3 | new value |

The value strings are the ones the device status report already sends to the backend, so the log and the report can't disagree.

## How changes are detected

Only location has a native change callback, so the check runs from several places and logs only when a value actually moved.

- The existing once-a-minute device info loop, which already read all three values but never compared them.
- `applicationDidBecomeActive`, so a change made in Settings while the app was backgrounded is caught on return.
- The existing `didChangeAuthorization` callback on the AppDelegate's location manager.
- A new `locationManagerDidChangeAuthorization` callback on the GPSManager's own location manager, which is the one that is actually live during data collection.

The app does not persist these values across launches. The first read after every launch is the baseline and is not logged as a change.

The location permission string mapping moved out of ApiManager into a shared `locationPermissionDescription()` in Common.swift. ApiManager now calls that instead of carrying its own copy of the switch.

## Also in this PR

A comment on `applicationWillTerminate` recording that the existing `terminate` event is best-effort. iOS does not call it on a force-quit from the app switcher, a jetsam kill, a crash, or a shutdown. No event was added or changed for this.

## Backend

Nothing needed. New rows go under the unchanged ios_log header, and `fix_app_log_file` in beiwe-backend only runs on Android log files.

## Not yet verified on a device

I could not build this locally (no CocoaPods on the machine), only parse-check the six edited files. Things to confirm on a real phone before merging.

- The new GPSManager callback fires once when the delegate is assigned. The baseline logic should absorb that without writing a row.
- Flipping location permission in Settings produces exactly one row, not one per trigger source.
- Notification and Background App Refresh changes show up within a minute or on the next foreground.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
