### PR TITLE
Fix surveyPushNotificationUUIDs being saved under the lastApplicationWillTerminate key

### DIFF
--- a/Beiwe/Models/Study.swift
+++ b/Beiwe/Models/Study.swift
@@ -72,7 +72,12 @@ class Study: ReclineObject {
         self.lastBackgroundPushNotificationReceived <- map["lastBackgroundPushNotificationReceived"]
         self.lastForegroundPushNotificationReceived <- map["lastForegroundPushNotificationReceived"]
         self.lastApplicationWillTerminate <- map["lastApplicationWillTerminate"]
-        self.surveyPushNotificationUUIDs <- map["lastApplicationWillTerminate"]
+        // Before 2.5.7 this line used the "lastApplicationWillTerminate" key (copy-paste bug). Being the last
+        // writer, the uuid list won the key on save, so lastApplicationWillTerminate always read back as
+        // never_populated, and the uuid list was silently correct. With the key fixed, the list starts over
+        // empty on the first launch after upgrade; that is fine, the backend already has every uuid the app
+        // reported (SurveyNotificationReport is create-or-ignore and only needs to see each uuid once).
+        self.surveyPushNotificationUUIDs <- map["surveyPushNotificationUUIDs"]
     }
 
     func surveyExists(surveyId: String?) -> Bool {


### PR DESCRIPTION
Fixes a copy-paste bug in `Study.mapping(map:)`. Both `lastApplicationWillTerminate` and `surveyPushNotificationUUIDs` were mapped to the `lastApplicationWillTerminate` key.

## What the bug did

ObjectMapper writes keys in mapping order, so the uuid list won the shared key on every save because it was the last writer. That means the uuid list was persisted and reloaded correctly the whole time. The casualty was `lastApplicationWillTerminate`. On launch it read back an array, failed the string cast, and reported `never_populated` to the backend after any relaunch.

## What changes

One line. The uuid list now maps to its own `surveyPushNotificationUUIDs` key. A comment records the history.

## Migration

None needed. After upgrade the old key still holds an array until the next terminate overwrites it with a string, and the string field ignores the array in the meantime. The uuid list starts empty under its new key. That is harmless. The backend stores each reported uuid in `SurveyNotificationReport` with a create-or-ignore bulk insert, and the resend service only needs to see a uuid once, so everything the device reported before the upgrade is already recorded.

Parse-checked only, not built locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
